### PR TITLE
feat: support for scope list in JWT token for scope validation

### DIFF
--- a/jose.go
+++ b/jose.go
@@ -152,12 +152,32 @@ func ScopesAllMatcher(scopesKey string, claims map[string]interface{}, requiredS
 	if !ok {
 		return false
 	}
-	scopeClaim, ok := tmp.(string)
+
+	scopes, ok := tmp.([]interface{})
+	if ok {
+		if len(scopes) > 0 {
+			for _, rScope := range requiredScopes {
+				matched := false
+				for _, pScope := range scopes {
+					if rScope == fmt.Sprintf("%s", pScope) {
+						matched = true
+					}
+				}
+				if matched == false { // required scope was not found --> immediately return
+					return false
+				}
+			}
+			// all required scopes have been found in provided (claims) scopes
+			return true
+		}
+	}
+
+	scopeString, ok := tmp.(string)
 	if !ok {
 		return false
 	}
 
-	presentScopes := strings.Split(scopeClaim, " ")
+	presentScopes := strings.Split(scopeString, " ")
 	if len(presentScopes) > 0 {
 		for _, rScope := range requiredScopes {
 			matched := false
@@ -197,6 +217,23 @@ func ScopesAnyMatcher(scopesKey string, claims map[string]interface{}, requiredS
 	if !ok {
 		return false
 	}
+
+	scopes, ok := tmp.([]interface{})
+	if ok {
+		if len(scopes) > 0 {
+			for _, rScope := range requiredScopes {
+				for _, pScope := range scopes {
+					if rScope == fmt.Sprintf("%s", pScope) {
+						return true // found any of the required scopes --> return
+					}
+				}
+			}
+
+			// none of the scopes have been found in provided (claims) scopes
+			return false
+		}
+	}
+
 	scopeClaim, ok := tmp.(string)
 	if !ok {
 		return false

--- a/jose_test.go
+++ b/jose_test.go
@@ -150,6 +150,71 @@ func TestScopesAllMatcher(t *testing.T) {
 		expected       bool
 	}{
 		{
+			name:           "all_simple_success_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a", "b"}},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+		{
+			name:           "all_simple_fail_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a", "b"}},
+			requiredScopes: []string{"c"},
+			expected:       false,
+		},
+		{
+			name:           "all_missingone_fail_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a", "b"}},
+			requiredScopes: []string{"a", "b", "c"},
+			expected:       false,
+		},
+		{
+			name:           "all_one_simple_success_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a", "b"}},
+			requiredScopes: []string{"b"},
+			expected:       true,
+		},
+		{
+			name:           "all_no_req_scopes_success_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a", "b"}},
+			requiredScopes: []string{},
+			expected:       true,
+		},
+		{
+			name:           "all_struct_success_for_scope_slice",
+			scopesKey:      "data.scope",
+			claims:         map[string]interface{}{"data": map[string]interface{}{"scope": []interface{}{"a", "b"}}},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+		{
+			name:      "all_deep_struct_success_for_scope_slice",
+			scopesKey: "data.data.data.data.data.data.data.scope",
+			claims: map[string]interface{}{
+				"data": map[string]interface{}{
+					"data": map[string]interface{}{
+						"data": map[string]interface{}{
+							"data": map[string]interface{}{
+								"data": map[string]interface{}{
+									"data": map[string]interface{}{
+										"data": map[string]interface{}{
+											"scope": []interface{}{"a", "b"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+		{
 			name:           "all_simple_success",
 			scopesKey:      "scope",
 			claims:         map[string]interface{}{"scope": "a b"},
@@ -230,6 +295,71 @@ func TestScopesAnyMatcher(t *testing.T) {
 		requiredScopes []string
 		expected       bool
 	}{
+		{
+			name:           "any_simple_success_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a", "b"}},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+		{
+			name:           "any_simple_fail_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a", "b"}},
+			requiredScopes: []string{"c"},
+			expected:       false,
+		},
+		{
+			name:           "any_missingone_success_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a"}},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+		{
+			name:           "any_one_simple_success_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a", "b"}},
+			requiredScopes: []string{"b"},
+			expected:       true,
+		},
+		{
+			name:           "any_no_req_scopes_success_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a", "b"}},
+			requiredScopes: []string{},
+			expected:       true,
+		},
+		{
+			name:           "any_struct_success_for_scope_slice",
+			scopesKey:      "data.scope",
+			claims:         map[string]interface{}{"data": map[string]interface{}{"scope": []interface{}{"a"}}},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+		{
+			name:      "any_deep_struct_success_for_scope_slice",
+			scopesKey: "data.data.data.data.data.data.data.scope",
+			claims: map[string]interface{}{
+				"data": map[string]interface{}{
+					"data": map[string]interface{}{
+						"data": map[string]interface{}{
+							"data": map[string]interface{}{
+								"data": map[string]interface{}{
+									"data": map[string]interface{}{
+										"data": map[string]interface{}{
+											"scope": []interface{}{"a"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
 		{
 			name:           "any_simple_success",
 			scopesKey:      "scope",


### PR DESCRIPTION
**Why**

When validating the JWT token, the original [krakend-jose](https://www.krakend.io/docs/authorization/jwt-validation/) only supports space-delimited scopes, e.g:
```
{
  ...
  "my_scopes": "scope1 scope2"
}
```

This PR makes `krakend-jose` also support scope list in JWT token , e.g:
```
{
  ...
  "my_scopes": ["scope1", "scope2"]
}
```