### PR TITLE
Clean propagated header claims

### DIFF
--- a/gin/jose_example_test.go
+++ b/gin/jose_example_test.go
@@ -326,12 +326,17 @@ func newVerifierEndpointCfg(alg, URL string, roles []string) *config.EndpointCon
 		},
 		ExtraConfig: config.ExtraConfig{
 			krakendjose.ValidatorNamespace: map[string]interface{}{
-				"alg":                  alg,
-				"jwk_url":              URL,
-				"audience":             []string{"http://api.example.com"},
-				"issuer":               "http://example.com",
-				"roles":                roles,
-				"propagate_claims":     [][]string{{"jti", "x-krakend-jti"}, {"sub", "x-krakend-sub"}, {"nonexistent", "x-krakend-ne"}, {"sub", "x-krakend-replace"}},
+				"alg":      alg,
+				"jwk_url":  URL,
+				"audience": []string{"http://api.example.com"},
+				"issuer":   "http://example.com",
+				"roles":    roles,
+				"propagate_claims": [][]string{
+					{"jti", "x-krakend-jti"},
+					{"sub", "x-krakend-sub"},
+					{"nonexistent", "x-krakend-ne"},
+					{"sub", "x-krakend-replace"},
+				},
 				"disable_jwk_security": true,
 				"cache":                true,
 			},

--- a/gin/jose_test.go
+++ b/gin/jose_test.go
@@ -147,6 +147,7 @@ func TestTokenSignatureValidator(t *testing.T) {
 	req.Header.Set("Authorization", "BEARER "+token)
 	// Check header-overwrite: it must be overwritten by a claim in the JWT!
 	req.Header.Set("x-krakend-replace", "abc")
+	req.Header.Set("x-krakend-ne", "fake_non_existing")
 
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)

--- a/jose.go
+++ b/jose.go
@@ -281,10 +281,7 @@ func CalculateHeadersToPropagate(propagationCfg [][]string, claims map[string]in
 	if len(propagationCfg) == 0 {
 		return nil, ErrNoHeadersToPropagate
 	}
-
 	propagated := make(map[string]string)
-
-	c := Claims(claims)
 
 	var err error
 	for _, tuple := range propagationCfg {
@@ -295,21 +292,13 @@ func CalculateHeadersToPropagate(propagationCfg [][]string, claims map[string]in
 		fromClaim := tuple[0]
 		toHeader := tuple[1]
 
+		c := Claims(claims)
 		if strings.Contains(fromClaim, ".") && (len(fromClaim) < 4 || fromClaim[:4] != "http") {
-			tmpKey, tmpClaims := getNestedClaim(fromClaim, claims)
-
-			tmp, ok := Claims(tmpClaims).Get(tmpKey)
-			if !ok {
-				continue
-			}
-			propagated[toHeader] = tmp
-			continue
+			var claimsMap map[string]interface{}
+			fromClaim, claimsMap = getNestedClaim(fromClaim, claims)
+			c = Claims(claimsMap)
 		}
-
-		v, ok := c.Get(fromClaim)
-		if !ok {
-			continue
-		}
+		v, _ := c.Get(fromClaim)
 		propagated[toHeader] = v
 	}
 

--- a/jose_test.go
+++ b/jose_test.go
@@ -313,7 +313,14 @@ func TestCalculateHeadersToPropagate(t *testing.T) {
 		expected map[string]string
 	}{
 		{
-			cfg: [][]string{{"a", "x-a"}, {"b", "x-b"}, {"c", "x-c"}, {"d.d", "x-d"}, {"d.d.c", "x-e"}},
+			cfg: [][]string{
+				{"a", "x-a"},
+				{"b", "x-b"},
+				{"c", "x-c"},
+				{"d.d", "x-d"},
+				{"d.d.c", "x-e"},
+				{"d.f", "x-f"},
+			},
 			claims: map[string]interface{}{
 				"a": 1,
 				"b": "foo",
@@ -329,7 +336,14 @@ func TestCalculateHeadersToPropagate(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]string{"x-a": "1", "x-b": "foo", "x-c": "one,two", "x-d": `{"a":1,"b":"foo","c":["one","two"]}`, "x-e": "one,two"},
+			expected: map[string]string{
+				"x-a": "1",
+				"x-b": "foo",
+				"x-c": "one,two",
+				"x-d": `{"a":1,"b":"foo","c":["one","two"]}`,
+				"x-e": "one,two",
+				"x-f": "",
+			},
 		},
 	} {
 		res, err := CalculateHeadersToPropagate(tc.cfg, tc.claims)
@@ -339,7 +353,7 @@ func TestCalculateHeadersToPropagate(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(tc.expected, res) {
-			t.Errorf("tc-%d: unexpected response: %v", i, res)
+			t.Errorf("tc-%d: got: %v want: %v", i, res, tc.expected)
 		}
 	}
 }


### PR DESCRIPTION
When we want a header to come from a jwt claim, we do not want it to be filled with data coming from the client.  With this PR, if there is no claim that matches the mapping, the header is set to an empty string.