### PR TITLE
Support non HTTP JWT validation

### DIFF
--- a/jose.go
+++ b/jose.go
@@ -353,6 +353,11 @@ var supportedAlgorithms = map[string]jose.SignatureAlgorithm{
 	"PS512": jose.PS512,
 }
 
+func SupportedAlgorithm(s string) (jose.SignatureAlgorithm, bool) {
+	a, ok := supportedAlgorithms[s]
+	return a, ok
+}
+
 func convertToStringSlice(input []interface{}) []string {
 	result := make([]string, len(input))
 

--- a/jwk_client.go
+++ b/jwk_client.go
@@ -82,7 +82,11 @@ func (j *JWKClient) GetSecret(r *http.Request) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+	return j.SecretFromToken(token)
+}
 
+// SecretFromToken implements the GetSecret method of the SecretProvider interface.
+func (j *JWKClient) SecretFromToken(token *jwt.JSONWebToken) (interface{}, error) {
 	if len(token.Headers) < 1 {
 		return nil, auth0.ErrNoJWTHeaders
 	}


### PR DESCRIPTION
Need to expose functions without a dependency on the `http` package to validate JWT